### PR TITLE
update links in readme; redirect fails git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ For now, I would of course only suggest you run this for development, and not tr
 anyways, if you still want to try it:
  - Install the latest Rust nightly, or close to it
  - Create a folder
- - clone https://github.com/kroeg/jsonld-rs, https://git.puckipedia.com/kroeg/tap, https://git.puckipedia.com/kroeg/cellar, and https://git.puckipedia.com/kroeg/server into this folder
+ - clone the following repos into this folder
+    - https://github.com/kroeg/jsonld-rs 
+    - https://puck.moe/git/kroeg/tap
+    - https://puck.moe/git/kroeg/cellar
+    - https://puck.moe/git/kroeg/server
  - Go to cellar, put the `.sql` file into your database.
  - Copy `server.toml.example` to `server.toml`, set it up as required.
  - Create root users with `cargo run --bin kroeg-call create https://example.com/~exampleUser exampleUser "Example User"`


### PR DESCRIPTION
when attempting to clone from links at `git.puckipedia.com`, i got the following redirect error: 

```
% git clone https://git.puckipedia.com/kroeg/tap
Cloning into 'tap'...
fatal: unable to update url base from redirection:
  asked for: https://git.puckipedia.com/kroeg/tap/info/refs?service=git-upload-pack
   redirect: https://puck.moe/git/kroeg/tap
```

so i updated the readme links to reflect the url we get redirected to.